### PR TITLE
storage: fix get_formats() return keys to match PVE::Storage::Plugin API

### DIFF
--- a/PVE/Storage/Custom/OntapNvmeTcpPlugin.pm
+++ b/PVE/Storage/Custom/OntapNvmeTcpPlugin.pm
@@ -1913,10 +1913,9 @@ sub volume_qemu_snapshot_method {
 
 sub get_formats {
     my ($class, $scfg, $storeid) = @_;
-
     return {
-        formats        => { raw => 1 },
-        default_format => 'raw',
+        valid   => { raw => 1 },
+        default => 'raw',
     };
 }
 


### PR DESCRIPTION
## Problem

`get_formats()` was returning `formats` and `default_format` as hash keys,
but `PVE::Storage::Plugin` expects `valid` and `default`.

This mismatch caused the format information to be silently ignored by PVE,
as the base class reads `$formats->{default}` and `$formats->{valid}`.

Reference: `PVE::Storage::Plugin::get_formats()` (pve-storage, src/PVE/Storage/Plugin.pm)

```perl
# base class expects:
return {
    default => $scfg->{format} || ...,
    valid   => { ... },
};
```

## Fix

Rename the return keys to match the expected API:
- `formats` -> `valid`
- `default_format` -> `default`

## Impact

- No functional change for the ONTAP backend itself (still raw-only)
- Fixes compatibility with APIVER 12+ format handling in pve-storage