### PR TITLE
storage: fetch uuid in list_cg_snapshots to populate volume_snapshot_info id field

### DIFF
--- a/PVE/Storage/OntapNvmeTcp/Api.pm
+++ b/PVE/Storage/OntapNvmeTcp/Api.pm
@@ -688,7 +688,7 @@ sub list_cg_snapshots {
     my ($self, $cg_uuid, $filter) = @_;
 
     my $q = "/application/consistency-groups/$cg_uuid"
-        . "/snapshots?fields=name,create_time,comment";
+        . "/snapshots?fields=uuid,name,create_time,comment";
     $q .= "&name=" . uri_escape($filter) if $filter;
 
     return $self->_get_all_records($q);


### PR DESCRIPTION
## Problem

`list_cg_snapshots()` was not requesting the `uuid` field from the ONTAP API.

As a result, `volume_snapshot_info()` always returned an empty string for the
`id` field of consistency-group snapshots:

```perl
$result{$pve} = {
    id => $s->{uuid} // '',  # always '' for CG snapshots
    ...
};
```

The APIVER 15 contract requires `id` to be a unique, stable identifier for
each snapshot (used for replication tracking).

## Fix

Add `uuid` to the `fields=` query parameter in `list_cg_snapshots()`.

## Impact

- No behavioral change for existing workflows
- Fixes APIVER 15 compliance for `volume_snapshot_info()` on CG snapshots